### PR TITLE
Build testing Dockerfile + build&test script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.19
+
+WORKDIR /app
+
+COPY ./cmd /app/cmd
+COPY ./internal /app/internal
+COPY ./pkg /app/pkg
+COPY ./Makefile /app/Makefile
+COPY ./go.mod /app/go.mod
+COPY ./go.sum /app/go.sum
+
+WORKDIR /app
+
+RUN make test

--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ environment variable `GCRCLEANER_CONCURRENCY` on the server. It defaults to 20.
 [container-registry]: https://cloud.google.com/container-registry
 [docker-hub]: https://hub.docker.com
 [go-re]: https://golang.org/pkg/regexp/syntax/
+
+
+# Testing
+You can build the test container and run it by running `docker-test.sh` from this directory.

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+docker build -t gcr-cleaner-test .
+
+docker run gcr-cleaner-test make test


### PR DESCRIPTION
Didn't want to install go 1.19 to test, this is easier.

The script could've been a `docker-compose` file but 🤷🏼 

```
🌥  ➜  gcr-cleaner git:(main) ✗ ./docker-test.sh 
[+] Building 0.6s (15/15) FINISHED                                                                                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                   0.0s
 => => transferring dockerfile: 251B                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.19                                                                                                                                                         0.5s
 => [ 1/10] FROM docker.io/library/golang:1.19@sha256:3025bf670b8363ec9f1b4c4f27348e6d9b7fec607c47e401e40df816853e743a                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                      0.0s
 => => transferring context: 949B                                                                                                                                                                                      0.0s
 => CACHED [ 2/10] WORKDIR /app                                                                                                                                                                                        0.0s
 => CACHED [ 3/10] COPY ./cmd /app/cmd                                                                                                                                                                                 0.0s
 => CACHED [ 4/10] COPY ./internal /app/internal                                                                                                                                                                       0.0s
 => CACHED [ 5/10] COPY ./pkg /app/pkg                                                                                                                                                                                 0.0s
 => CACHED [ 6/10] COPY ./Makefile /app/Makefile                                                                                                                                                                       0.0s
 => CACHED [ 7/10] COPY ./go.mod /app/go.mod                                                                                                                                                                           0.0s
 => CACHED [ 8/10] COPY ./go.sum /app/go.sum                                                                                                                                                                           0.0s
 => CACHED [ 9/10] WORKDIR /app                                                                                                                                                                                        0.0s
 => CACHED [10/10] RUN make test                                                                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                                0.0s
 => => writing image sha256:595a30690b3552a93a2db70300c2404246d1166bb2e9fb4f5d43d6c85b34096b                                                                                                                           0.0s
 => => naming to docker.io/library/gcr-cleaner-test                                                                                                                                                                    0.0s
?       github.com/GoogleCloudPlatform/gcr-cleaner/cmd/gcr-cleaner-cli  [no test files]
?       github.com/GoogleCloudPlatform/gcr-cleaner/cmd/gcr-cleaner-server       [no test files]
?       github.com/GoogleCloudPlatform/gcr-cleaner/internal/bearerkeychain      [no test files]
?       github.com/GoogleCloudPlatform/gcr-cleaner/internal/version     [no test files]
?       github.com/GoogleCloudPlatform/gcr-cleaner/internal/worker      [no test files]
ok      github.com/GoogleCloudPlatform/gcr-cleaner/pkg/gcrcleaner       0.046s
```