### PR TITLE
Implement Repo Targeting and Tag Keep Filters

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -63,7 +63,7 @@ func NewCleaner(keychain gcrauthn.Keychain, logger *Logger, concurrency int64) (
 
 // Clean deletes old images from GCR that are (un)tagged and older than "since"
 // and higher than the "keep" amount.
-func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep int64, repoKeepMatcher ItemFilter, tagFilter ItemFilter, podFilter PodFilter, dryRun bool) ([]string, error) {
+func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep int64, repoKeepMatcher ItemFilter, repoPrefixFilter ItemFilter, tagFilter ItemFilter, tagKeepFilter ItemFilter, podFilter PodFilter, dryRun bool) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
@@ -136,7 +136,7 @@ func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep 
 			"uploaded", m.Info.Uploaded.Format(time.RFC3339))
 
 		// Do nothing if this is not a candidate.
-		if !c.shouldDelete(m, since, repoKeepMatcher, tagFilter, podFilter) {
+		if !c.shouldDelete(m, since, repoKeepMatcher, repoPrefixFilter, tagFilter, tagKeepFilter, podFilter) {
 			c.logger.Debug("skipping deletion because of filters",
 				"repo", repo,
 				"digest", m.Digest,
@@ -330,7 +330,7 @@ func (c *Cleaner) deleteOne(ctx context.Context, ref gcrname.Reference) error {
 
 // shouldDelete returns true if the manifest was created before the given
 // timestamp and either has no tags or has tags that match the given filter.
-func (c *Cleaner) shouldDelete(m *manifest, since time.Time, repoSkipFilter ItemFilter, tagFilter ItemFilter, podFilter PodFilter) bool {
+func (c *Cleaner) shouldDelete(m *manifest, since time.Time, repoSkipFilter ItemFilter, repoPrefixFilter ItemFilter, tagFilter ItemFilter, tagKeepFilter ItemFilter, podFilter PodFilter) bool {
 	// Immediately exclude images that have been uploaded after the given time.
 	if uploaded := m.Info.Uploaded.UTC(); uploaded.After(since) {
 		c.logger.Debug("should not delete",
@@ -373,13 +373,15 @@ func (c *Cleaner) shouldDelete(m *manifest, since time.Time, repoSkipFilter Item
 	}
 
 	// If tagged images are allowed and the given filter matches the list of tags,
-	// this is a deletion candidate. The default tag filter is to reject all
-	// strings.
-	if tagFilter.Matches(m.Info.Tags) {
+	// and the repository matches the given filter, then this is a deletion
+	// The default tag filter is to reject all strings.
+	// The default repo filter is to accept all strings.
+	// The default tag keep filter is to accept all strings.
+	if tagFilter.Matches(m.Info.Tags) && repoPrefixFilter.Matches([]string{m.Repo}) && !tagKeepFilter.Matches(m.Info.Tags) {
 		c.logger.Debug("should delete",
 			"repo", m.Repo,
 			"digest", m.Digest,
-			"reason", "matches tag filter",
+			"reason", "matches tag and repo filter but does not match tag keep filter",
 			"tags", m.Info.Tags,
 			"tag_filter", tagFilter.Name())
 		return true


### PR DESCRIPTION
Repo targeting will allow us to be more deliberate in what we're attempting to delete (in the case of a spammy repository) and the Tag Keep filters will let us keep important images that should not be cleaned up.

These get us closer to parity on Artifact Registry's cleanup policies. 