### PR TITLE
Include Pods without init containers in in-use images query

### DIFF
--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -200,7 +200,8 @@ func (s *Server) clean(ctx context.Context, r io.ReadCloser) (map[string][]strin
 
 	podFilter := NewAssetPodFilter(repos)
 
-	recentlySeenImagesQuery := `SELECT DISTINCT JSON_VALUE(container, '$.image') as image
+	recentlySeenImagesQuery := `
+SELECT DISTINCT JSON_VALUE(container, '$.image') as image
 FROM (
   SELECT
     CASE asset_type
@@ -208,8 +209,11 @@ FROM (
         JSON_QUERY_ARRAY(
           resource.data,'$.spec.containers'
         ),
-        JSON_QUERY_ARRAY(
-          resource.data,'$.spec.initContainers'
+        COALESCE(
+          JSON_QUERY_ARRAY(
+            resource.data,'$.spec.initContainers'
+          ),
+          []
         )
       )
       WHEN "run.googleapis.com/Service" THEN JSON_QUERY_ARRAY(


### PR DESCRIPTION
BigQuery's `ARRAY_CONCAT` function [returns null when any of its arguments are null](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_concat). This led the in-use container images query to ignore Pods without init containers. The broken query returns 517 distinct images seen in the past week, versus 1,448 with the fixed query--big oops!