### PR TITLE
Sundry polish

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -214,6 +214,13 @@ func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep 
 						return "", nil
 					}
 
+					if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+						c.logger.Warn("failed to delete digest because it does not exist",
+							"repo", repo,
+							"digest", digest)
+						return "", nil
+					}
+
 					return "", fmt.Errorf("failed to delete digest %s: %w", digest, err)
 				}
 			}


### PR DESCRIPTION
This PR makes two polish improvements:
1. Don't fail the cleaner job if an image we want to delete doesn't exist. This appears to happen occasionally when multiple delete calls are issued for the same image version.
2. Parameterize the details of the BigQuery table containing Cloud Asset Inventory data.