### PR TITLE
Don't delete images referenced by CronJobs

### DIFF
--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -220,6 +220,17 @@ FROM (
           []
         )
       )
+      WHEN "batch.k8s.io/CronJob" THEN ARRAY_CONCAT(
+        JSON_QUERY_ARRAY(
+          resource.data,'$.spec.jobTemplate.spec.template.spec.containers'
+        ),
+        COALESCE(
+          JSON_QUERY_ARRAY(
+            resource.data,'$.spec.jobTemplate.spec.template.spec.initContainers'
+          ),
+          []
+        )
+      )
       WHEN "run.googleapis.com/Service" THEN JSON_QUERY_ARRAY(
         resource.data,'$.spec.template.spec.containers'
       )


### PR DESCRIPTION
Include k8s CronJobs in recently used images query, since their Pods are ephemeral and likely to be missing from snapshots.

In the most recent snapshot, this raises the number of distinct images seen from 956 to 960--not a huge difference, but still mitigates some inadvertent deletion.

Follow on to https://github.com/discord/discord/pull/191131.