### PR TITLE
Warn instead of error on missing images in second delete call (retry).

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -268,6 +268,14 @@ func (c *Cleaner) Clean(ctx context.Context, repo string, since time.Time, keep 
 							toRetryLock.Unlock()
 							return "", nil
 						}
+
+						if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+							c.logger.Warn("failed to delete digest because it does not exist",
+								"repo", repo,
+								"digest", digest)
+							return "", nil
+						}
+
 						return "", fmt.Errorf("failed to delete digest %s: %w", digest, err)
 					}
 				}


### PR DESCRIPTION
Follow on to https://github.com/discord/gcr-cleaner/pull/9. We want to just warn on any delete call for a nonexistent image.